### PR TITLE
Collapse /props call to a single autoload=true request

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -149,13 +149,10 @@ export default async function (pi: ExtensionAPI) {
 		pendingContext.add(modelId);
 		const controller = new AbortController();
 		const timer = setTimeout(() => controller.abort(), PROPS_TIMEOUT_MS);
-		const propsBase = `${baseUrl.replace(/\/v1$/, "")}/props?model=${encodeURIComponent(modelId)}&autoload=`;
+		const propsUrl = `${baseUrl.replace(/\/v1$/, "")}/props?model=${encodeURIComponent(modelId)}&autoload=true`;
 
 		try {
-			let response = await fetch(`${propsBase}false`, { signal: controller.signal });
-			if (response.status === 400 || response.status === 404) {
-				response = await fetch(`${propsBase}true`, { signal: controller.signal });
-			}
+			const response = await fetch(propsUrl, { signal: controller.signal });
 			if (!response.ok) {
 				ctx.ui.notify(`[llama-cpp] /props for ${modelId} returned ${response.status}`, "error");
 				return;


### PR DESCRIPTION
## Summary
- `discoverContextWindow` used to hit `/props?...&autoload=false` first and only retry with `autoload=true` on 400/404. When the model isn't already loaded that retry was the only path that succeeded, so the first call was wasted.
- Collapses to a single `autoload=true` call.

cc @hanouticelina for review.

## Test plan
- [ ] `npx oxfmt --check .` passes
- [ ] `npx oxlint .` passes
- [ ] Manually trigger context-window discovery against a llama-server instance and confirm `/props` is only called once and the response is parsed correctly.