### PR TITLE
Add template-based thinking support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -215,11 +215,6 @@ export default async function (pi: ExtensionAPI) {
 
 		try {
 			const response = await fetch(propsUrl, { signal: controller.signal });
-			if (!autoload && (response.status === 400 || response.status === 404)) {
-				// Model isn't loaded and we asked the server not to load it.
-				// Skip silently; lazy discovery on model_select will pick it up.
-				return;
-			}
 			if (!response.ok) {
 				ctx?.ui.notify(`[llama-cpp] /props for ${modelId} returned ${response.status}`, "error");
 				return;

--- a/index.ts
+++ b/index.ts
@@ -238,6 +238,9 @@ export default async function (pi: ExtensionAPI) {
 				applyTemplateThinkingSupport(model);
 				if (selectedModel) {
 					applyTemplateThinkingSupport(selectedModel);
+					if (pi.getThinkingLevel() === "off") {
+						pi.setThinkingLevel("medium");
+					}
 				}
 				updated = true;
 			}
@@ -278,6 +281,7 @@ export default async function (pi: ExtensionAPI) {
 		void discoverModelMetadata(event.model.id, ctx, true, PROPS_TIMEOUT_MS, event.model);
 	});
 
+	// Discover /props for already-active models because re-selecting them does not emit model_select.
 	pi.on("before_provider_request", (event, ctx) => {
 		const modelId = (event.payload as { model?: unknown })?.model;
 		if (typeof modelId === "string") {

--- a/index.ts
+++ b/index.ts
@@ -16,9 +16,6 @@ const DEFAULT_BASE_URL = "http://localhost:8080/v1";
 // Fallback for /v1/models entries missing meta.n_ctx.
 const DEFAULT_CONTEXT_WINDOW = 8192;
 const PROPS_TIMEOUT_MS = 120_000;
-// Eager startup probe never autoloads; a short timeout bounds pi startup
-// latency even when the router has many cold or slow models.
-const PROPS_EAGER_TIMEOUT_MS = 5_000;
 
 const ModelsResponseSchema = Type.Object({
 	data: Type.Optional(
@@ -271,11 +268,6 @@ export default async function (pi: ExtensionAPI) {
 	}
 
 	await refreshProvider();
-	// Probe already-loaded models before the first request can be built; /v1/models
-	// lacks chat_template, and autoload=false avoids loading cold router models.
-	await Promise.allSettled(
-		currentModels.map((m) => discoverModelMetadata(m.id, undefined, false, PROPS_EAGER_TIMEOUT_MS)),
-	);
 
 	pi.on("input", async (event) => {
 		const trimmed = event.text.trim().toLowerCase();

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,9 @@ const DEFAULT_BASE_URL = "http://localhost:8080/v1";
 // Fallback for /v1/models entries missing meta.n_ctx.
 const DEFAULT_CONTEXT_WINDOW = 8192;
 const PROPS_TIMEOUT_MS = 120_000;
+// Eager startup probe never autoloads; a short timeout bounds pi startup
+// latency even when the router has many cold or slow models.
+const PROPS_EAGER_TIMEOUT_MS = 5_000;
 
 const ModelsResponseSchema = Type.Object({
 	data: Type.Optional(
@@ -59,12 +62,40 @@ const PropsResponseSchema = Type.Object({
 			n_ctx: Type.Optional(Type.Number()),
 		}),
 	),
+	chat_template: Type.Optional(Type.String()),
 });
 
 const validatePropsResponse = Compile(PropsResponseSchema);
 
 type LlamaModel = NonNullable<Parameters<ExtensionAPI["registerProvider"]>[1]["models"]>[number];
 type ExtensionCtx = Parameters<Parameters<ExtensionAPI["on"]>[1]>[1];
+
+// llama.cpp template thinking is boolean, so expose Pi's default off/medium toggle only.
+const TEMPLATE_THINKING_LEVEL_MAP = {
+	minimal: null,
+	low: null,
+	high: null,
+	xhigh: null,
+} satisfies NonNullable<LlamaModel["thinkingLevelMap"]>;
+
+// Minimal shape needed to update both registered models and Pi's active model snapshot.
+type MutableThinkingModel = {
+	reasoning: boolean;
+	thinkingLevelMap?: LlamaModel["thinkingLevelMap"];
+	compat?: LlamaModel["compat"];
+};
+
+// Mark a model as using llama.cpp's chat_template_kwargs.enable_thinking control.
+function applyTemplateThinkingSupport(model: MutableThinkingModel): void {
+	model.reasoning = true;
+	model.thinkingLevelMap = TEMPLATE_THINKING_LEVEL_MAP;
+	model.compat = {
+		...model.compat,
+		// Despite the Pi enum name, this sends llama.cpp's generic
+		// chat_template_kwargs.enable_thinking payload, not a Qwen-only option.
+		thinkingFormat: "qwen-chat-template",
+	};
+}
 
 export default async function (pi: ExtensionAPI) {
 	let currentModels: LlamaModel[] = [];
@@ -108,6 +139,7 @@ export default async function (pi: ExtensionAPI) {
 			const previousById = new Map(currentModels.map((m) => [m.id, m]));
 
 			currentModels = (payload.data ?? []).map((model) => {
+				const previous = previousById.get(model.id);
 				const isLoaded = model.status?.value === "loaded";
 				const modalities = model.architecture?.input_modalities ?? ["text"];
 				const input = modalities.filter(
@@ -123,12 +155,14 @@ export default async function (pi: ExtensionAPI) {
 				return {
 					id: model.id,
 					name: suffixes.length > 0 ? `${model.id} ${suffixes.join(" ")}` : model.id,
+					// /v1/models does not include /props-discovered capabilities, so preserve
+					// template thinking metadata across refreshes.
+					reasoning: previous?.reasoning ?? false,
+					thinkingLevelMap: previous?.thinkingLevelMap,
 					input,
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-					contextWindow:
-						model.meta?.n_ctx ??
-						previousById.get(model.id)?.contextWindow ??
-						DEFAULT_CONTEXT_WINDOW,
+					contextWindow: model.meta?.n_ctx ?? previous?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+					compat: previous?.compat,
 				} as LlamaModel;
 			});
 
@@ -149,27 +183,48 @@ export default async function (pi: ExtensionAPI) {
 		}
 	}
 
-	const discoveredContext = new Set<string>();
-	const pendingContext = new Set<string>();
+	const discoveredMetadata = new Set<string>();
+	const pendingMetadata = new Set<string>();
 
-	async function discoverContextWindow(modelId: string, ctx: ExtensionCtx): Promise<void> {
-		if (discoveredContext.has(modelId) || pendingContext.has(modelId)) {
-			return;
-		}
+	async function discoverModelMetadata(
+		modelId: string,
+		ctx?: ExtensionCtx,
+		autoload = true,
+		timeoutMs = PROPS_TIMEOUT_MS,
+		selectedModel?: MutableThinkingModel,
+	): Promise<void> {
 		const model = currentModels.find((m) => m.id === modelId);
 		if (!model) {
 			return;
 		}
+		if (discoveredMetadata.has(modelId)) {
+			// Provider re-registration does not update Pi's active model snapshot, so copy
+			// already-discovered thinking metadata into the selected model when available.
+			if (selectedModel && model.reasoning) {
+				selectedModel.reasoning = model.reasoning;
+				selectedModel.thinkingLevelMap = model.thinkingLevelMap;
+				selectedModel.compat = model.compat;
+			}
+			return;
+		}
+		if (pendingMetadata.has(modelId)) {
+			return;
+		}
 
-		pendingContext.add(modelId);
+		pendingMetadata.add(modelId);
 		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), PROPS_TIMEOUT_MS);
-		const propsUrl = `${baseUrl.replace(/\/v1$/, "")}/props?model=${encodeURIComponent(modelId)}&autoload=true`;
+		const timer = setTimeout(() => controller.abort(), timeoutMs);
+		const propsUrl = `${baseUrl.replace(/\/v1$/, "")}/props?model=${encodeURIComponent(modelId)}&autoload=${autoload}`;
 
 		try {
 			const response = await fetch(propsUrl, { signal: controller.signal });
+			if (!autoload && (response.status === 400 || response.status === 404)) {
+				// Model isn't loaded and we asked the server not to load it.
+				// Skip silently; lazy discovery on model_select will pick it up.
+				return;
+			}
 			if (!response.ok) {
-				ctx.ui.notify(`[llama-cpp] /props for ${modelId} returned ${response.status}`, "error");
+				ctx?.ui.notify(`[llama-cpp] /props for ${modelId} returned ${response.status}`, "error");
 				return;
 			}
 			const data: unknown = await response.json();
@@ -177,33 +232,50 @@ export default async function (pi: ExtensionAPI) {
 				const errors = [...validatePropsResponse.Errors(data)]
 					.map((e) => `${"path" in e ? e.path : ""} ${e.message}`)
 					.join("; ");
-				ctx.ui.notify(`[llama-cpp] invalid /props response for ${modelId}: ${errors}`, "error");
+				ctx?.ui.notify(`[llama-cpp] invalid /props response for ${modelId}: ${errors}`, "error");
 				return;
 			}
 			const nCtx = data.default_generation_settings?.n_ctx;
+			let updated = false;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
-				discoveredContext.add(modelId);
-				pi.registerProvider(PROVIDER_ID, {
-					name: "llama.cpp",
-					baseUrl,
-					apiKey,
-					api: "openai-completions",
-					models: currentModels,
-				});
-				ctx.ui.notify(`[llama-cpp] contextWindow=${nCtx} for ${modelId}`, "info");
+				ctx?.ui.notify(`[llama-cpp] contextWindow=${nCtx} for ${modelId}`, "info");
+				updated = true;
 			}
+			if (data.chat_template?.includes("enable_thinking") === true) {
+				applyTemplateThinkingSupport(model);
+				if (selectedModel) {
+					applyTemplateThinkingSupport(selectedModel);
+				}
+				updated = true;
+			}
+			discoveredMetadata.add(modelId);
+			if (!updated) {
+				return;
+			}
+			pi.registerProvider(PROVIDER_ID, {
+				name: "llama.cpp",
+				baseUrl,
+				apiKey,
+				api: "openai-completions",
+				models: currentModels,
+			});
 		} catch (error) {
 			const err = error as Error;
 			const msg = err.name === "AbortError" ? "timeout" : err.message;
-			ctx.ui.notify(`[llama-cpp] /props for ${modelId} failed: ${msg}`, "error");
+			ctx?.ui.notify(`[llama-cpp] /props for ${modelId} failed: ${msg}`, "error");
 		} finally {
 			clearTimeout(timer);
-			pendingContext.delete(modelId);
+			pendingMetadata.delete(modelId);
 		}
 	}
 
 	await refreshProvider();
+	// Probe already-loaded models before the first request can be built; /v1/models
+	// lacks chat_template, and autoload=false avoids loading cold router models.
+	await Promise.allSettled(
+		currentModels.map((m) => discoverModelMetadata(m.id, undefined, false, PROPS_EAGER_TIMEOUT_MS)),
+	);
 
 	pi.on("input", async (event) => {
 		const trimmed = event.text.trim().toLowerCase();
@@ -216,13 +288,15 @@ export default async function (pi: ExtensionAPI) {
 		if (event.model.provider !== PROVIDER_ID) {
 			return;
 		}
-		void discoverContextWindow(event.model.id, ctx);
+		void discoverModelMetadata(event.model.id, ctx, true, PROPS_TIMEOUT_MS, event.model);
 	});
 
 	pi.on("before_provider_request", (event, ctx) => {
 		const modelId = (event.payload as { model?: unknown })?.model;
 		if (typeof modelId === "string") {
-			void discoverContextWindow(modelId, ctx);
+			const activeModel =
+				ctx.model?.provider === PROVIDER_ID && ctx.model.id === modelId ? ctx.model : undefined;
+			void discoverModelMetadata(modelId, ctx, true, PROPS_TIMEOUT_MS, activeModel);
 		}
 	});
 }


### PR DESCRIPTION
This PR adds template-based thinking support. When `/props` exposes a `chat_template` containing `enable_thinking`, the extension now marks that model as reasoning-capable and configures Pi to send llama.cpp-compatible:
   ```json
   {
     "chat_template_kwargs": {
       "enable_thinking": true,
       "preserve_thinking": true
     }
   }
 ```
Before this PR, Pi registered  models as `reasoning: false`, so it never sent `chat_template_kwargs.enable_thinking=false` when thinking was turned off. the server fell back to its template default, which enables thinking for templates that support it. this made thinking effectively always on and not controllable from Pi.
This PR enables Pi’s thinking toggle for llama.cpp templates that expose an `enable_thinking` control.
