### PR TITLE
Notify the user when llama-server is unreachable

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -116,11 +116,13 @@ export default async function (pi: ExtensionAPI) {
 	const baseUrl = (process.env.LLAMA_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
 	const apiKey = process.env.LLAMA_API_KEY ?? "no-key";
 
-	async function refreshProvider(): Promise<void> {
+	async function refreshProvider(ctx?: ExtensionCtx): Promise<void> {
 		try {
 			const response = await fetch(`${baseUrl}/models`);
 			if (!response.ok) {
-				console.warn(`[llama-cpp] ${baseUrl}/models returned ${response.status}`);
+				const msg = `${baseUrl}/models returned ${response.status}`;
+				console.warn(`[llama-cpp] ${msg}`);
+				ctx?.ui.notify(`[llama-cpp] ${msg}`, "error");
 				return;
 			}
 
@@ -129,7 +131,9 @@ export default async function (pi: ExtensionAPI) {
 				const errors = [...validateModelsResponse.Errors(payload)]
 					.map((e) => `${"path" in e ? e.path : ""} ${e.message}`)
 					.join("; ");
-				console.warn(`[llama-cpp] invalid /models response: ${errors}`);
+				const msg = `invalid /models response: ${errors}`;
+				console.warn(`[llama-cpp] ${msg}`);
+				ctx?.ui.notify(`[llama-cpp] ${msg}`, "error");
 				return;
 			}
 
@@ -164,7 +168,9 @@ export default async function (pi: ExtensionAPI) {
 			});
 
 			if (currentModels.length === 0) {
-				console.warn(`[llama-cpp] no models returned from ${baseUrl}/models`);
+				const msg = `no models returned from ${baseUrl}/models`;
+				console.warn(`[llama-cpp] ${msg}`);
+				ctx?.ui.notify(`[llama-cpp] ${msg}`, "error");
 				return;
 			}
 
@@ -176,7 +182,12 @@ export default async function (pi: ExtensionAPI) {
 				models: currentModels,
 			});
 		} catch (error) {
-			console.warn(`[llama-cpp] failed to reach ${baseUrl}/models: ${(error as Error).message}`);
+			const reason = (error as Error).message;
+			console.warn(`[llama-cpp] failed to reach ${baseUrl}/models: ${reason}`);
+			ctx?.ui.notify(
+				`[llama-cpp] llama-server not reachable at ${baseUrl} (${reason}). Start it with: llama-server -hf <repo>`,
+				"error",
+			);
 		}
 	}
 
@@ -267,10 +278,10 @@ export default async function (pi: ExtensionAPI) {
 
 	await refreshProvider();
 
-	pi.on("input", async (event) => {
+	pi.on("input", async (event, ctx) => {
 		const trimmed = event.text.trim().toLowerCase();
 		if (trimmed === "/model") {
-			await refreshProvider();
+			await refreshProvider(ctx);
 		}
 	});
 


### PR DESCRIPTION
## Summary

- When `/v1/models` fails (connection refused, non-2xx, schema mismatch, empty list), surface the error via `ctx.ui.notify` instead of only `console.warn` — the latter is invisible inside pi, so today the user sees an empty model picker with no explanation.
- The connection-refused message includes the configured `LLAMA_BASE_URL` and a "start with: `llama-server -hf <repo>`" hint, mirroring how `ollama` prints "could not connect to ollama app, is it running?" when its daemon is down.
- Threads an optional `ctx` parameter through `refreshProvider` and passes it from the `/model` input handler. Startup still calls `refreshProvider()` without a ctx — pi isn't rendered yet, so the notifications are intentional no-ops (same pattern as the eager `/props` probe documented in the thinking-mode notes).

## Test plan

- [ ] With llama-server **not** running: launch pi, type `/model` → see an `[llama-cpp] llama-server not reachable at http://localhost:8080/v1 (...)` notification with the start hint.
- [ ] With llama-server running but returning 5xx on `/v1/models`: type `/model` → see `[llama-cpp] http://localhost:8080/v1/models returned 503`.
- [ ] With llama-server running and serving models: type `/model` → no error notification; model list refreshes as before.
- [ ] Startup with llama-server down: pi still starts (no crash, no notification spam), and `console.warn` still logs to the host shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)