### PR TITLE
feat: add llama-swap support, JSON config, and verbose discovery logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # pi-llama
 
-llama.cpp Pi extension. Auto-discovers models from a running `llama-server` and
-registers them as the `llama-cpp` provider in pi.
+llama.cpp / llama-swap Pi extension. Auto-discovers models from a running
+`llama-server` or `llama-swap` and registers them as a configurable provider
+in pi.
 
 ## Install
 
@@ -32,18 +33,80 @@ pi -e ~/code/pi-llama/index.ts
 `-e` loads the extension only for the current session, useful while
 developing.
 
+## Configuration
+
+Create `~/.pi/agent/pi-llama.json` for global config or
+`./.pi/pi-llama.json` for project-local overrides. Both are JSON files; the
+project-local file takes precedence.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `baseUrl` | `http://localhost:8080/v1` | API base URL (no trailing slash) |
+| `providerId` | `llama-cpp` | Provider ID for model registration |
+| `llamaSwapMode` | `false` | Use `/upstream/:id/props` instead of `/props?model=:id` |
+| `defaultContextWindow` | `8192` | Fallback context window when `/v1/models` omits `n_ctx` |
+| `propsTimeoutMs` | `120000` | Timeout for props discovery (ms) — increase for large models on slow networks. |
+| `logPropsDiscovery` | `false` | Log verbose /props discovery progress (start, elapsed time, errors) to the notification area. |
+| `apiKey` | `no-key` | API key forwarded to the provider |
+
+Environment variables take precedence over config file values:
+- `LLAMA_BASE_URL` overrides `baseUrl`
+- `LLAMA_API_KEY` overrides `apiKey`
+
+#### Verbose discovery logging
+
+Set `"logPropsDiscovery": true` to log verbose /props discovery progress to
+the notification area. This is off by default to keep the notification area
+clean. When enabled you'll see messages like:
+
+```
+[llama-cpp] fetching /props for qwen3.6-35b-a3b-mtp…
+[llama-cpp] contextWindow=262144 for qwen3.6-35b-a3b-mtp (33ms to resolve /props)
+```
+
+This is useful for debugging slow or failing model metadata discovery.
+
+### llama-swap
+
+To use with [llama-swap](https://github.com/refvm/llama-swap), set
+`llamaSwapMode: true`. llama-swap does not expose a root `/props` endpoint;
+instead it routes model details through
+`/upstream/:modelid/props`.
+
+Example `~/.pi/agent/pi-llama.json` for llama-swap:
+
+```json
+{
+  "baseUrl": "http://localhost:8080/v1",
+  "providerId": "llama-cpp",
+  "llamaSwapMode": true,
+  "defaultContextWindow": 8192
+}
+```
+
 ## Usage
 
 ```bash
-# 1. Install llama-server
-curl -LsSf https://llama.app/install.sh | bash
-
-# 2. Start it
+# 1. Install and start llama-server
 llama-server
 
-# 3. Launch pi
+# 2. Or start llama-swap
+llama-swap
+
+# 3. Configure ~/.pi/agent/pi-llama.json as needed
+
+# 4. Launch pi
 pi
 
-# 4. Inside pi
-/model              # pick llama-cpp/<id>
+# 5. Inside pi
+/model              # pick models from your provider
+```
+
+### Environment Variable Override
+
+You can override `baseUrl` and `apiKey` via environment variables without
+editing the config file:
+
+```bash
+LLAMA_BASE_URL=http://10.0.0.5:3000/v1 LLAMA_API_KEY=secret pi
 ```

--- a/index.ts
+++ b/index.ts
@@ -1,15 +1,126 @@
 /**
  * llama.cpp provider for pi.
  *
- * Auto-discovers models from a running `llama-server` and
+ * Auto-discovers models from a running `llama-server` or `llama-swap` and
  * registers them under the `llama-cpp` provider.
+ *
+ * Config file (merged, project takes precedence):
+ * - `~/.pi/agent/pi-llama.json` (global)
+ * - `./.pi/pi-llama.json` (project-local)
+ *
+ * Example pi-llama.json:
+ * ```json
+ * {
+ *   "baseUrl": "http://localhost:8080/v1",
+ *   "providerId": "llama-swap",
+ *   "llamaSwapMode": true,
+ *   "defaultContextWindow": 8192,
+ *   "propsTimeoutMs": 120000,
+ *   "apiKey": "no-key"
+ * }
+ * ```
+ *
+ * `llamaSwapMode: true` tells the extension to use
+ * `/upstream/:modelid/props` instead of `/props?model=:id`.
  *
  * Usage: `pi install github.com/huggingface/pi-llama`
  */
 
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { Compile } from "typebox/compile";
+
+// ---- Config ---------------------------------------------------------------
+
+/** Shape of the pi-llama.json configuration file. */
+interface PiLlamaConfig {
+	/** Base URL of the llama-server / llama-swap API. */
+	baseUrl?: string;
+	/** Provider ID used to register models. */
+	providerId?: string;
+	/** Use llama-swap upstream props endpoint (`/upstream/:id/props`). */
+	llamaSwapMode?: boolean;
+	/** Default context window when /v1/models does not report n_ctx. */
+	defaultContextWindow?: number;
+	/** Timeout in ms for props discovery requests. */
+	propsTimeoutMs?: number;
+	/** API key passed to the provider (default: "no-key"). */
+	apiKey?: string;
+	/** Log verbose /props discovery progress (start, elapsed time, errors). */
+	logPropsDiscovery?: boolean;
+}
+
+/** Sensible defaults for the global pi-llama.json. */
+const DEFAULT_GLOBAL_CONFIG: PiLlamaConfig = {
+	baseUrl: "http://localhost:8080/v1",
+	providerId: "llama-cpp",
+	llamaSwapMode: false,
+	defaultContextWindow: 8192,
+	propsTimeoutMs: 120000,
+	apiKey: "no-key",
+	logPropsDiscovery: false,
+};
+
+/**
+ * Create the global pi-llama.json with defaults if it does not already exist.
+ */
+function ensureGlobalConfig(): void {
+	const globalPath = join(getAgentDir(), "pi-llama.json");
+	if (existsSync(globalPath)) {
+		return;
+	}
+	try {
+		const agentDir = getAgentDir();
+		if (!existsSync(agentDir)) {
+			mkdirSync(agentDir, { recursive: true });
+		}
+		writeFileSync(globalPath, JSON.stringify(DEFAULT_GLOBAL_CONFIG, null, 2) + "\n", "utf-8");
+		console.info(`[pi-llama] Created global config: ${globalPath}`);
+	} catch (err) {
+		console.warn(`[pi-llama] Failed to create global config: ${(err as Error).message}`);
+	}
+}
+
+/**
+ * Load merged config from global and project-local pi-llama.json files.
+ *
+ * Project-local config (`./.pi/pi-llama.json`) takes precedence over the
+ * global config (`~/.pi/agent/pi-llama.json`).
+ */
+function loadConfig(cwd: string): PiLlamaConfig {
+	const globalPath = join(getAgentDir(), "pi-llama.json");
+	const projectPath = join(cwd, ".pi", "pi-llama.json");
+
+	let globalConfig: PiLlamaConfig = {};
+	let projectConfig: PiLlamaConfig = {};
+
+	// Load global config
+	if (existsSync(globalPath)) {
+		try {
+			globalConfig = JSON.parse(readFileSync(globalPath, "utf-8"));
+		} catch {
+			console.warn(`[pi-llama] Failed to parse global config: ${globalPath}`);
+		}
+	}
+
+	// Load project-local config (overrides global)
+	if (existsSync(projectPath)) {
+		try {
+			projectConfig = JSON.parse(readFileSync(projectPath, "utf-8"));
+		} catch {
+			console.warn(`[pi-llama] Failed to parse project config: ${projectPath}`);
+		}
+	}
+
+	// Merge: project overrides global
+	return { ...globalConfig, ...projectConfig };
+}
+
+// ---- Defaults (overridden by config) --------------------------------------
 
 const PROVIDER_ID = "llama-cpp";
 const DEFAULT_BASE_URL = "http://localhost:8080/v1";
@@ -113,8 +224,22 @@ export default async function (pi: ExtensionAPI) {
 		},
 	});
 
-	const baseUrl = (process.env.LLAMA_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
-	const apiKey = process.env.LLAMA_API_KEY ?? "no-key";
+	// Merge env vars (highest priority) with loaded config, falling back to defaults.
+	ensureGlobalConfig();
+	const config = loadConfig(process.cwd());
+
+	const resolvedBaseUrl =
+		process.env.LLAMA_BASE_URL ??
+		config.baseUrl ??
+		DEFAULT_BASE_URL;
+	const resolvedProviderId = config.providerId ?? PROVIDER_ID;
+	const resolvedApiKey = process.env.LLAMA_API_KEY ?? config.apiKey ?? "no-key";
+	const resolvedContextWindow = config.defaultContextWindow ?? DEFAULT_CONTEXT_WINDOW;
+	const resolvedPropsTimeoutMs = config.propsTimeoutMs ?? PROPS_TIMEOUT_MS;
+	const llamaSwapMode = !!config.llamaSwapMode;
+	const logPropsDiscovery = !!config.logPropsDiscovery;
+
+	const baseUrl = resolvedBaseUrl.replace(/\/+$/, "");
 
 	async function refreshProvider(): Promise<void> {
 		try {
@@ -158,7 +283,8 @@ export default async function (pi: ExtensionAPI) {
 					thinkingLevelMap: previous?.thinkingLevelMap,
 					input,
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-					contextWindow: model.meta?.n_ctx ?? previous?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+					contextWindow:
+						model.meta?.n_ctx ?? previous?.contextWindow ?? resolvedContextWindow,
 					compat: previous?.compat,
 				} as LlamaModel;
 			});
@@ -168,10 +294,10 @@ export default async function (pi: ExtensionAPI) {
 				return;
 			}
 
-			pi.registerProvider(PROVIDER_ID, {
+			pi.registerProvider(resolvedProviderId, {
 				name: "llama.cpp",
 				baseUrl,
-				apiKey,
+				apiKey: resolvedApiKey,
 				api: "openai-completions",
 				models: currentModels,
 			});
@@ -187,7 +313,7 @@ export default async function (pi: ExtensionAPI) {
 		modelId: string,
 		ctx?: ExtensionCtx,
 		autoload = true,
-		timeoutMs = PROPS_TIMEOUT_MS,
+		timeoutMs = resolvedPropsTimeoutMs,
 		selectedModel?: MutableThinkingModel,
 	): Promise<void> {
 		const model = currentModels.find((m) => m.id === modelId);
@@ -211,27 +337,52 @@ export default async function (pi: ExtensionAPI) {
 		pendingMetadata.add(modelId);
 		const controller = new AbortController();
 		const timer = setTimeout(() => controller.abort(), timeoutMs);
-		const propsUrl = `${baseUrl.replace(/\/v1$/, "")}/props?model=${encodeURIComponent(modelId)}&autoload=${autoload}`;
+		// llama-swap exposes model props at /upstream/:id/props;
+		// vanilla llama-server uses /props?model=:id&autoload=:bool
+		const propsBase = baseUrl.replace(/\/v1$/, "");
+		const propsUrl = llamaSwapMode
+			? `${propsBase}/upstream/${encodeURIComponent(modelId)}/props`
+			: `${propsBase}/props?model=${encodeURIComponent(modelId)}&autoload=${autoload}`;
+
+		const startedAt = performance.now();
+
+		// Log that we're waiting so the user knows discovery is in progress.
+		if (logPropsDiscovery) {
+			ctx?.ui.notify(`[llama-cpp] fetching /props for ${modelId}…`, "info");
+		}
 
 		try {
 			const response = await fetch(propsUrl, { signal: controller.signal });
+			const data: unknown = await response.json();
+			const elapsed = Math.round(performance.now() - startedAt);
+
 			if (!response.ok) {
-				ctx?.ui.notify(`[llama-cpp] /props for ${modelId} returned ${response.status}`, "error");
+				ctx?.ui.notify(
+					`[llama-cpp] /props for ${modelId} returned ${response.status} (${elapsed}ms to resolve /props)`,
+					"error",
+				);
 				return;
 			}
-			const data: unknown = await response.json();
 			if (!validatePropsResponse.Check(data)) {
 				const errors = [...validatePropsResponse.Errors(data)]
 					.map((e) => `${"path" in e ? e.path : ""} ${e.message}`)
 					.join("; ");
-				ctx?.ui.notify(`[llama-cpp] invalid /props response for ${modelId}: ${errors}`, "error");
+				ctx?.ui.notify(
+					`[llama-cpp] invalid /props response for ${modelId} (${elapsed}ms to resolve /props): ${errors}`,
+					"error",
+				);
 				return;
 			}
 			const nCtx = data.default_generation_settings?.n_ctx;
 			let updated = false;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
-				ctx?.ui.notify(`[llama-cpp] contextWindow=${nCtx} for ${modelId}`, "info");
+				if (logPropsDiscovery) {
+					ctx?.ui.notify(
+						`[llama-cpp] contextWindow=${nCtx} for ${modelId} (${elapsed}ms to resolve /props)`,
+						"info",
+					);
+				}
 				updated = true;
 			}
 			if (data.chat_template?.includes("enable_thinking") === true) {
@@ -246,19 +397,29 @@ export default async function (pi: ExtensionAPI) {
 			}
 			discoveredMetadata.add(modelId);
 			if (!updated) {
+				if (logPropsDiscovery) {
+					ctx?.ui.notify(
+						`[llama-cpp] no new metadata for ${modelId} (${elapsed}ms to resolve /props)`,
+						"info",
+					);
+				}
 				return;
 			}
-			pi.registerProvider(PROVIDER_ID, {
+			pi.registerProvider(resolvedProviderId, {
 				name: "llama.cpp",
 				baseUrl,
-				apiKey,
+				apiKey: resolvedApiKey,
 				api: "openai-completions",
 				models: currentModels,
 			});
 		} catch (error) {
+			const elapsed = Math.round(performance.now() - startedAt);
 			const err = error as Error;
 			const msg = err.name === "AbortError" ? "timeout" : err.message;
-			ctx?.ui.notify(`[llama-cpp] /props for ${modelId} failed: ${msg}`, "error");
+			ctx?.ui.notify(
+				`[llama-cpp] /props for ${modelId} failed: ${msg} (${elapsed}ms to resolve /props)`,
+				"error",
+			);
 		} finally {
 			clearTimeout(timer);
 			pendingMetadata.delete(modelId);
@@ -267,6 +428,20 @@ export default async function (pi: ExtensionAPI) {
 
 	await refreshProvider();
 
+	// Discover /props for models that are already active on session start.
+	// This ensures context window and reasoning capabilities are discovered
+	// even when resuming sessions or when a model is pre-selected.
+	// Note: ctx.model may be undefined if the session started without a model selected,
+	// or if model resolution happens after session_start fires.
+	// In that case, the model_select event will handle it.
+	const sessionStartHandler = (_event: { type: "session_start"; reason: string; previousSessionFile?: string }, ctx: { model?: any }) => {
+		if (ctx.model?.provider === resolvedProviderId) {
+			void discoverModelMetadata(ctx.model.id, ctx, true, resolvedPropsTimeoutMs, ctx.model);
+		}
+	};
+	pi.on("session_start", sessionStartHandler);
+
+	// If model_select fires (user selects a model), discover its props.
 	pi.on("input", async (event) => {
 		const trimmed = event.text.trim().toLowerCase();
 		if (trimmed === "/model") {
@@ -275,10 +450,10 @@ export default async function (pi: ExtensionAPI) {
 	});
 
 	pi.on("model_select", (event, ctx) => {
-		if (event.model.provider !== PROVIDER_ID) {
+		if (event.model.provider !== resolvedProviderId) {
 			return;
 		}
-		void discoverModelMetadata(event.model.id, ctx, true, PROPS_TIMEOUT_MS, event.model);
+		void discoverModelMetadata(event.model.id, ctx, true, resolvedPropsTimeoutMs, event.model);
 	});
 
 	// Discover /props for already-active models because re-selecting them does not emit model_select.
@@ -286,8 +461,8 @@ export default async function (pi: ExtensionAPI) {
 		const modelId = (event.payload as { model?: unknown })?.model;
 		if (typeof modelId === "string") {
 			const activeModel =
-				ctx.model?.provider === PROVIDER_ID && ctx.model.id === modelId ? ctx.model : undefined;
-			void discoverModelMetadata(modelId, ctx, true, PROPS_TIMEOUT_MS, activeModel);
+				ctx.model?.provider === resolvedProviderId && ctx.model.id === modelId ? ctx.model : undefined;
+			void discoverModelMetadata(modelId, ctx, true, resolvedPropsTimeoutMs, activeModel);
 		}
 	});
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                  
   Adds configurable JSON-based settings, llama-swap compatibility, optional verbose discovery logging, and auto-creation of the default config file.                                                             
                                                                                                                                                                                                                  
   ## Features                                                                                                                                                                                                    
                                                                                                                                                                                                                  
   ### JSON Config (`~/.pi/agent/pi-llama.json` / `./.pi/pi-llama.json`)                                                                                                                                          
                                                                                                                                                                                                                  
   Both are JSON files; project-local (`.pi/pi-llama.json`) takes precedence over global (`~/.pi/agent/pi-llama.json`). All key constants are now overridable:                                                    
                                                                                                                                                                                                                  
   | Key | Default | Description |                                                                                                                                                                                
   |-----|---------|-------------|                                                                                                                                                                                
   | `baseUrl` | `http://localhost:8080/v1` | API base URL (no trailing slash) |                                                                                                                                  
   | `providerId` | `llama-cpp` | Provider ID for model registration |                                                                                                                                            
   | `llamaSwapMode` | `false` | Use `/upstream/:id/props` instead of `/props?model=:id` |                                                                                                                        
   | `defaultContextWindow` | `8192` | Fallback when `/v1/models` omits `n_ctx` |                                                                                                                                 
   | `propsTimeoutMs` | `120000` | Timeout for props discovery (increase for large models) |                                                                                                                      
   | `logPropsDiscovery` | `false` | Log verbose /props discovery progress |                                                                                                                                      
   | `apiKey` | `no-key` | API key forwarded to the provider |                                                                                                                                                    
                                                                                                                                                                                                                  
   Environment variables (`LLAMA_BASE_URL`, `LLAMA_API_KEY`) take precedence over config file values.                                                                                                             
                                                                                                                                                                                                                  
   A default `~/.pi/agent/pi-llama.json` is auto-created on first load if it doesn't exist.                                                                                                                       
                                                                                                                                                                                                                  
   ### llama-swap Support                                                                                                                                                                                         
                                                                                                                                                                                                                  
   Set `"llamaSwapMode": true` to use llama-swap's `/upstream/:modelid/props` endpoint instead of the vanilla `/props?model=:id` endpoint.                                                                        
                                                                                                                                                                                                                  
   Example config:                                                                                                                                                                                                
                                                                                                                                                                                                                  
   ```json
   {
     "baseUrl": "http://localhost:8080/v1",
     "providerId": "llama-cpp",
     "llamaSwapMode": true,
     "defaultContextWindow": 8192,
     "propsTimeoutMs": 120000,
     "apiKey": "no-key",
     "logPropsDiscovery": false
   }
   ```
   ### Verbose Discovery Logging (Optional)                                                                                                                                                                         
                                                                                                                                                                                                                  
 Set "logPropsDiscovery": true to see verbose /props discovery progress in notifications. This is off by default to keep things clean. When enabled:                                                              
                                                                                                                                                                                                                  
 ```                                                                                                                                                                                                              
   [llama-cpp] fetching /props for qwen3.6-35b-a3b-mtp…
   [llama-cpp] contextWindow=262144 for qwen3.6-35b-a3b-mtp (33ms to resolve /props)
 ```                                                                                                                                                                                                              
                                                                                                                                                                                                                  
 Useful for debugging slow or failing metadata discovery.                                                                                                                                                         
                                                                                                                                                                                                                  
 ### Session Resume                                                                                                                                                                                               
                                                                                                                                                                                                                  
 Added session_start handler so props (context window, thinking capabilities) are discovered for already-active models when a session starts, resumes, forks, or trees. This fixes the issue where context window 
 defaulted to 8192 instead of the actual value from /props.                                                                                                                                                       
                                                                                                                                                                                                                  
 Changes                                                                                                                                                                                                          
                                                                                                                                                                                                                  
 - index.ts: Added config loading, llama-swap mode, verbose logging, session start handler                                                                                                                        
 - README.md: Updated with config reference table, llama-swap instructions, env var overrides