### PR TITLE
Improve  loading status display

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -94,6 +94,13 @@ function applyTemplateThinkingSupport(model: MutableThinkingModel): void {
 	};
 }
 
+function formatContextWindow(tokens: number): string {
+	const kib = tokens / 1024;
+	return Number.isInteger(kib)
+		? `${kib >= 1024 ? `${kib / 1024}M` : `${kib}K`} tokens`
+		: `${tokens.toLocaleString("en-US")} tokens`;
+}
+
 export default async function (pi: ExtensionAPI) {
 	let currentModels: LlamaModel[] = [];
 
@@ -212,10 +219,17 @@ export default async function (pi: ExtensionAPI) {
 		const controller = new AbortController();
 		const timer = setTimeout(() => controller.abort(), timeoutMs);
 		const propsUrl = `${baseUrl.replace(/\/v1$/, "")}/props?model=${encodeURIComponent(modelId)}&autoload=${autoload}`;
+		const clearFooterStatusLater = () =>
+			setTimeout(() => ctx?.ui.setStatus(PROVIDER_ID, undefined), 8000);
 
 		try {
+			if (autoload && ctx) {
+				ctx.ui.setStatus(PROVIDER_ID, ctx.ui.theme.fg("dim", `[llama.cpp] loading: ${modelId}`));
+			}
+
 			const response = await fetch(propsUrl, { signal: controller.signal });
 			if (!response.ok) {
+				ctx?.ui.setStatus(PROVIDER_ID, undefined);
 				ctx?.ui.notify(`[llama-cpp] /props for ${modelId} returned ${response.status}`, "error");
 				return;
 			}
@@ -224,14 +238,16 @@ export default async function (pi: ExtensionAPI) {
 				const errors = [...validatePropsResponse.Errors(data)]
 					.map((e) => `${"path" in e ? e.path : ""} ${e.message}`)
 					.join("; ");
+				ctx?.ui.setStatus(PROVIDER_ID, undefined);
 				ctx?.ui.notify(`[llama-cpp] invalid /props response for ${modelId}: ${errors}`, "error");
 				return;
 			}
 			const nCtx = data.default_generation_settings?.n_ctx;
 			let updated = false;
+			let loadedFooterStatus = autoload ? `llama.cpp loaded: ${modelId}` : undefined;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
-				ctx?.ui.notify(`[llama-cpp] contextWindow=${nCtx} for ${modelId}`, "info");
+				loadedFooterStatus = `[llama.cpp] ${modelId} (ctx ${formatContextWindow(nCtx)}) loaded`;
 				updated = true;
 			}
 			if (data.chat_template?.includes("enable_thinking") === true) {
@@ -245,6 +261,10 @@ export default async function (pi: ExtensionAPI) {
 				updated = true;
 			}
 			discoveredMetadata.add(modelId);
+			if (loadedFooterStatus && ctx) {
+				ctx.ui.setStatus(PROVIDER_ID, ctx.ui.theme.fg("dim", loadedFooterStatus));
+				clearFooterStatusLater();
+			}
 			if (!updated) {
 				return;
 			}
@@ -258,6 +278,7 @@ export default async function (pi: ExtensionAPI) {
 		} catch (error) {
 			const err = error as Error;
 			const msg = err.name === "AbortError" ? "timeout" : err.message;
+			ctx?.ui.setStatus(PROVIDER_ID, undefined);
 			ctx?.ui.notify(`[llama-cpp] /props for ${modelId} failed: ${msg}`, "error");
 		} finally {
 			clearTimeout(timer);

--- a/index.ts
+++ b/index.ts
@@ -237,10 +237,10 @@ export default async function (pi: ExtensionAPI) {
 			}
 			const nCtx = data.default_generation_settings?.n_ctx;
 			let updated = false;
-			let loadedFooterStatus = autoload ? `[llama.cpp] loaded: ${modelId}` : undefined;
+			let loadedFooterStatus = autoload ? `[llama.cpp] ${modelId} loaded` : undefined;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
-				loadedFooterStatus = `[llama.cpp] loaded: ${modelId} ctx ${nCtx} tokens`;
+				loadedFooterStatus = `[llama.cpp] ${modelId} loaded with ctx ${nCtx} tokens`;
 				updated = true;
 			}
 			if (data.chat_template?.includes("enable_thinking") === true) {

--- a/index.ts
+++ b/index.ts
@@ -94,13 +94,6 @@ function applyTemplateThinkingSupport(model: MutableThinkingModel): void {
 	};
 }
 
-function formatContextWindow(tokens: number): string {
-	const kib = tokens / 1024;
-	return Number.isInteger(kib)
-		? `${kib >= 1024 ? `${kib / 1024}M` : `${kib}K`} tokens`
-		: `${tokens.toLocaleString("en-US")} tokens`;
-}
-
 export default async function (pi: ExtensionAPI) {
 	let currentModels: LlamaModel[] = [];
 
@@ -244,10 +237,10 @@ export default async function (pi: ExtensionAPI) {
 			}
 			const nCtx = data.default_generation_settings?.n_ctx;
 			let updated = false;
-			let loadedFooterStatus = autoload ? `llama.cpp loaded: ${modelId}` : undefined;
+			let loadedFooterStatus = autoload ? `[llama.cpp] loaded: ${modelId}` : undefined;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
-				loadedFooterStatus = `[llama.cpp] ${modelId} (ctx ${formatContextWindow(nCtx)}) loaded`;
+				loadedFooterStatus = `[llama.cpp] loaded: ${modelId} ctx ${nCtx} tokens`;
 				updated = true;
 			}
 			if (data.chat_template?.includes("enable_thinking") === true) {


### PR DESCRIPTION
Small aesthetic only logging update for model loading. shows loading/loaded messages in the footer instead of the conversation.
 
<img width="1712" height="938" alt="Screenshot 2026-05-27 at 16 30 00" src="https://github.com/user-attachments/assets/a1577307-5b1f-4cff-882a-df10bb97b849" />
<img width="1716" height="942" alt="Screenshot 2026-05-27 at 16 29 32" src="https://github.com/user-attachments/assets/a36b2fd9-cd1e-490b-9653-4d8cf6da8960" />


No behavior changes.