### PR TITLE
Get versioning from props; Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ pi -e ~/code/pi-llama/index.ts
 `-e` loads the extension only for the current session, useful while
 developing.
 
+## Environment Variables
+
+This extension supports the following environment variables:
+
+- LLAMA_BASE_URL (Default: `http://localhost:8080/v1`)
+- LLAMA_API_KEY (Default: `no-key`)
+
 ## Usage
 
 ```bash
@@ -40,6 +47,9 @@ curl -LsSf https://llama.app/install.sh | bash
 
 # 2. Start the server
 llama serve
+
+# Optional: Use a remote instance of llama.cpp server instead of local
+export LLAMA_BASE_URL="https://llama.example.com/v1"
 
 # 3. Launch pi in another terminal
 pi

--- a/index.ts
+++ b/index.ts
@@ -60,6 +60,7 @@ const PropsResponseSchema = Type.Object({
 		}),
 	),
 	chat_template: Type.Optional(Type.String()),
+	build_info: Type.Optional(Type.String()),
 });
 
 const validatePropsResponse = Compile(PropsResponseSchema);
@@ -98,18 +99,30 @@ export default async function (pi: ExtensionAPI) {
 	let currentModels: LlamaModel[] = [];
 
 	pi.registerCommand("llama-version", {
-		description: "Print llama-server --version output",
+		description: "Get build info of llama.cpp server",
 		handler: async (_args, ctx) => {
-			const result = await pi.exec("llama-server", ["--version"]);
-			const output = `${result.stderr ?? ""}\n${result.stdout ?? ""}`;
-			const versionLine = output
-				.split("\n")
-				.map((l) => l.trim())
-				.find((l) => /^version:\s/i.test(l));
-			ctx.ui.notify(
-				versionLine ?? `llama-server exited with code ${result.code}`,
-				versionLine ? "info" : "error",
-			);
+			const response = await fetch(`${baseUrl.replace(/\/v1$/, "")}/props`);
+			if (!response.ok) {
+				ctx.ui.notify(`[llama-cpp] /props returned ${response.status}`, "error");
+				return;
+			}
+
+			const data: unknown = await response.json();
+			if (!validatePropsResponse.Check(data)) {
+				const errors = [...validatePropsResponse.Errors(data)]
+					.map((e) => `${"path" in e ? e.path : ""} ${e.message}`)
+					.join("; ");
+				ctx.ui.notify(`[llama-cpp] invalid /props response: ${errors}`, "error");
+				return;
+			}
+
+			const match = data.build_info?.match(/^b([a-zA-Z0-9]+)-([a-zA-Z0-9]+)$/);
+
+			if (match && match.length === 3) {
+				ctx.ui.notify(`Build number: ${match[1]}, Commit hash: ${match[2]}`, "info");
+			} else {
+				ctx.ui.notify(`Malformed build info: ${data.build_info}`, "warning");
+			}
 		},
 	});
 


### PR DESCRIPTION
I use a remote instance of llama.cpp server, so the current version checking behavior does not work for me.

To fix this, I replaced the current logic with a `/props` API call to the running llama.cpp server.

I also updated the README for users who also host llama.cpp remotely.