### PR TITLE
Fix llama.cpp model metadata and print-mode cleanup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -79,6 +79,7 @@ const TEMPLATE_THINKING_LEVEL_MAP = {
 // Minimal shape needed to update both registered models and Pi's active model snapshot.
 type MutableThinkingModel = {
 	reasoning: boolean;
+	maxTokens?: number;
 	thinkingLevelMap?: LlamaModel["thinkingLevelMap"];
 	compat?: LlamaModel["compat"];
 };
@@ -172,6 +173,7 @@ export default async function (pi: ExtensionAPI) {
 					input,
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 					contextWindow: model.meta?.n_ctx ?? previous?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+					maxTokens: model.meta?.n_ctx ?? previous?.maxTokens ?? DEFAULT_CONTEXT_WINDOW,
 					compat: previous?.compat,
 				} as LlamaModel;
 			});
@@ -253,6 +255,7 @@ export default async function (pi: ExtensionAPI) {
 			let loadedFooterStatus = autoload ? `[llama.cpp] ${modelId} loaded` : undefined;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
+				model.maxTokens = nCtx;
 				loadedFooterStatus = `[llama.cpp] ${modelId} loaded with ctx ${nCtx} tokens`;
 				updated = true;
 			}

--- a/index.ts
+++ b/index.ts
@@ -228,7 +228,13 @@ export default async function (pi: ExtensionAPI) {
 		const timer = setTimeout(() => controller.abort(), timeoutMs);
 		const propsUrl = `${baseUrl.replace(/\/v1$/, "")}/props?model=${encodeURIComponent(modelId)}&autoload=${autoload}`;
 		const clearFooterStatusLater = () =>
-			setTimeout(() => ctx?.ui.setStatus(PROVIDER_ID, undefined), 8000);
+			setTimeout(() => {
+				try {
+					ctx?.ui.setStatus(PROVIDER_ID, undefined);
+				} catch {
+					// Print mode can retire the extension context before this timer fires.
+				}
+			}, 8000);
 
 		try {
 			if (autoload && ctx) {


### PR DESCRIPTION
This sets maxTokens alongside contextWindow from llama.cpp n_ctx metadata so pi --list-models can render local llama.cpp models without crashing. It also updates the /props refresh path to keep both values in sync after model metadata discovery.

This also guards the delayed footer status clear because print mode can retire the extension context before that timer fires. Without the guard, pi -p can return the model output successfully and then crash from a stale extension context.

I formatted/linted with oxfmt, oxlint, tested with pi --list-models, and pi -p against llama.cpp.