### PR TITLE
fix(metadata): set llama max token counts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -79,6 +79,7 @@ const TEMPLATE_THINKING_LEVEL_MAP = {
 // Minimal shape needed to update both registered models and Pi's active model snapshot.
 type MutableThinkingModel = {
 	reasoning: boolean;
+	maxTokens?: number;
 	thinkingLevelMap?: LlamaModel["thinkingLevelMap"];
 	compat?: LlamaModel["compat"];
 };
@@ -172,6 +173,7 @@ export default async function (pi: ExtensionAPI) {
 					input,
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 					contextWindow: model.meta?.n_ctx ?? previous?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+					maxTokens: model.meta?.n_ctx ?? previous?.maxTokens ?? DEFAULT_CONTEXT_WINDOW,
 					compat: previous?.compat,
 				} as LlamaModel;
 			});
@@ -253,6 +255,7 @@ export default async function (pi: ExtensionAPI) {
 			let loadedFooterStatus = autoload ? `[llama.cpp] ${modelId} loaded` : undefined;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
+				model.maxTokens = nCtx;
 				loadedFooterStatus = `[llama.cpp] ${modelId} loaded with ctx ${nCtx} tokens`;
 				updated = true;
 			}


### PR DESCRIPTION
Set maxTokens alongside contextWindow from llama.cpp n_ctx metadata. Pi expects both fields when listing models, so llama.cpp models with only contextWindow could crash pi --list-models.

The /props refresh path now keeps maxTokens in sync with contextWindow after model metadata discovery.

Verified with oxfmt, oxlint, and pi --list-models against a local llama.cpp server.