### PR TITLE
fix(ui): clear stale footer timeouts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -195,6 +195,14 @@ export default async function (pi: ExtensionAPI) {
 
 	const discoveredMetadata = new Set<string>();
 	const pendingMetadata = new Set<string>();
+	let statusTimeout: ReturnType<typeof setTimeout> | undefined;
+
+	function clearFooterStatusTimeout(): void {
+		if (statusTimeout !== undefined) {
+			clearTimeout(statusTimeout);
+			statusTimeout = undefined;
+		}
+	}
 
 	async function discoverModelMetadata(
 		modelId: string,
@@ -225,8 +233,13 @@ export default async function (pi: ExtensionAPI) {
 		const controller = new AbortController();
 		const timer = setTimeout(() => controller.abort(), timeoutMs);
 		const propsUrl = `${baseUrl.replace(/\/v1$/, "")}/props?model=${encodeURIComponent(modelId)}&autoload=${autoload}`;
-		const clearFooterStatusLater = () =>
-			setTimeout(() => ctx?.ui.setStatus(PROVIDER_ID, undefined), 8000);
+		const clearFooterStatusLater = () => {
+			clearFooterStatusTimeout();
+			statusTimeout = setTimeout(() => {
+				statusTimeout = undefined;
+				ctx?.ui.setStatus(PROVIDER_ID, undefined);
+			}, 8000);
+		};
 
 		try {
 			if (autoload && ctx) {
@@ -316,5 +329,9 @@ export default async function (pi: ExtensionAPI) {
 				ctx.model?.provider === PROVIDER_ID && ctx.model.id === modelId ? ctx.model : undefined;
 			void discoverModelMetadata(modelId, ctx, true, PROPS_TIMEOUT_MS, activeModel);
 		}
+	});
+
+	pi.on("session_shutdown", () => {
+		clearFooterStatusTimeout();
 	});
 }


### PR DESCRIPTION
Track the delayed footer status timeout and clear it when the session shuts down. This prevents print-mode runs from returning output successfully and then crashing when the timer fires against a retired extension context.

The change also clears any previous footer timeout before scheduling a new one and unsets the timeout after it fires.

Verified with oxfmt, oxlint, and pi -p against a local llama.cpp server.