### PR TITLE
Set `maxTokens` on registered models

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,10 @@ const PROVIDER_ID = "llama-cpp";
 const DEFAULT_BASE_URL = "http://localhost:8080/v1";
 // Fallback for /v1/models entries missing meta.n_ctx.
 const DEFAULT_CONTEXT_WINDOW = 8192;
+// llama.cpp has no output-token cap (no endpoint reports one; generation is only
+// bounded by the context window), so use Pi's own default for models that omit
+// maxTokens (see model-registry.ts parseModels).
+const DEFAULT_MAX_TOKENS = 16384;
 const PROPS_TIMEOUT_MS = 120_000;
 
 const ModelsResponseSchema = Type.Object({
@@ -76,14 +80,16 @@ const TEMPLATE_THINKING_LEVEL_MAP = {
 } satisfies NonNullable<LlamaModel["thinkingLevelMap"]>;
 
 // Minimal shape needed to update both registered models and Pi's active model snapshot.
-type MutableThinkingModel = {
+type MutableModelMetadata = {
 	reasoning: boolean;
 	thinkingLevelMap?: LlamaModel["thinkingLevelMap"];
 	compat?: LlamaModel["compat"];
+	contextWindow: number;
+	maxTokens: number;
 };
 
 // Mark a model as using llama.cpp's chat_template_kwargs.enable_thinking control.
-function applyTemplateThinkingSupport(model: MutableThinkingModel): void {
+function applyTemplateThinkingSupport(model: MutableModelMetadata): void {
 	model.reasoning = true;
 	model.thinkingLevelMap = TEMPLATE_THINKING_LEVEL_MAP;
 	model.compat = {
@@ -149,6 +155,8 @@ export default async function (pi: ExtensionAPI) {
 				if (isLoaded) {
 					suffixes.push("(loaded)");
 				}
+				const contextWindow =
+					model.meta?.n_ctx ?? previous?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
 				return {
 					id: model.id,
 					name: suffixes.length > 0 ? `${model.id} ${suffixes.join(" ")}` : model.id,
@@ -158,7 +166,8 @@ export default async function (pi: ExtensionAPI) {
 					thinkingLevelMap: previous?.thinkingLevelMap,
 					input,
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-					contextWindow: model.meta?.n_ctx ?? previous?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+					contextWindow,
+					maxTokens: Math.min(DEFAULT_MAX_TOKENS, contextWindow),
 					compat: previous?.compat,
 				} as LlamaModel;
 			});
@@ -188,7 +197,7 @@ export default async function (pi: ExtensionAPI) {
 		ctx?: ExtensionCtx,
 		autoload = true,
 		timeoutMs = PROPS_TIMEOUT_MS,
-		selectedModel?: MutableThinkingModel,
+		selectedModel?: MutableModelMetadata,
 	): Promise<void> {
 		const model = currentModels.find((m) => m.id === modelId);
 		if (!model) {
@@ -196,11 +205,15 @@ export default async function (pi: ExtensionAPI) {
 		}
 		if (discoveredMetadata.has(modelId)) {
 			// Provider re-registration does not update Pi's active model snapshot, so copy
-			// already-discovered thinking metadata into the selected model when available.
-			if (selectedModel && model.reasoning) {
-				selectedModel.reasoning = model.reasoning;
-				selectedModel.thinkingLevelMap = model.thinkingLevelMap;
-				selectedModel.compat = model.compat;
+			// already-discovered metadata into the selected model when available.
+			if (selectedModel) {
+				selectedModel.contextWindow = model.contextWindow;
+				selectedModel.maxTokens = model.maxTokens;
+				if (model.reasoning) {
+					selectedModel.reasoning = model.reasoning;
+					selectedModel.thinkingLevelMap = model.thinkingLevelMap;
+					selectedModel.compat = model.compat;
+				}
 			}
 			return;
 		}
@@ -231,8 +244,13 @@ export default async function (pi: ExtensionAPI) {
 			let updated = false;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
+				model.maxTokens = Math.min(DEFAULT_MAX_TOKENS, nCtx);
 				ctx?.ui.notify(`[llama-cpp] contextWindow=${nCtx} for ${modelId}`, "info");
 				updated = true;
+			}
+			if (selectedModel) {
+				selectedModel.contextWindow = model.contextWindow;
+				selectedModel.maxTokens = model.maxTokens;
 			}
 			if (data.chat_template?.includes("enable_thinking") === true) {
 				applyTemplateThinkingSupport(model);


### PR DESCRIPTION
Fixes #16

pi's model type requires `maxTokens`, but the extension never set it. ii's `registerProvider` path takes the value as is,  unlike built-in model providers, no default is applied so registered models carried `maxTokens: undefined`, and `pi --list-models` crashed.

---

**Investigation by Claude Code:**
`llama.cpp` has no per-model output-token limit, and no endpoint reports one:

- `/v1/models` has no output-cap concept, only context metadata (`meta.n_ctx`, `n_ctx_train`).
- `/props` reports default_generation_settings.params.max_tokens, but it is always -1 (= unlimited) - even when the server runs with `--n-predict`, since the snapshot is built from default-constructed params (only sampling settings are copied in; verified on current master and older builds). The cap is enforced at runtime but never exposed.
- Generation is only ever bounded by the context window (prompt + output ≤ `n_ctx`).

So there is nothing meaningful to fetch. Instead, use Pi's own convention: `16384`,  the same default Pi applies to `models.json` models that omit maxTokens - clamped to the context window, since an output limit larger than the total token budget is impossible (this only kicks in for servers running with `n_ctx` < `16384`).

---

_Note_: `maxTokens` is not set equal to `contextWindow` (see #14) - it stays a separate output limit; the window is only an upper bound.