### PR TITLE
fix: improve llama.cpp multimodal capability detection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -103,7 +103,7 @@ const TEMPLATE_THINKING_LEVEL_MAP = {
 } satisfies NonNullable<LlamaModel["thinkingLevelMap"]>;
 
 // Minimal shape needed to update both registered models and Pi's active model snapshot.
-type MutableDiscoveredModel = {
+type MutableModelMetadata = {
 	id: string;
 	name: string;
 	input: LlamaModel["input"];
@@ -115,7 +115,7 @@ type MutableDiscoveredModel = {
 };
 
 // Mark a model as using llama.cpp's chat_template_kwargs.enable_thinking control.
-function applyTemplateThinkingSupport(model: MutableDiscoveredModel): void {
+function applyTemplateThinkingSupport(model: MutableModelMetadata): void {
 	model.reasoning = true;
 	model.thinkingLevelMap = TEMPLATE_THINKING_LEVEL_MAP;
 	model.compat = {
@@ -175,7 +175,7 @@ function getDiscoveredCapabilitiesFromListing(model: {
 }
 
 function applyPropsModalities(
-	model: MutableDiscoveredModel,
+	model: MutableModelMetadata,
 	isLoaded: boolean,
 	capabilities: DiscoveredCapabilities,
 	modalities?: { vision?: boolean; audio?: boolean; video?: boolean },
@@ -324,7 +324,7 @@ export default async function (pi: ExtensionAPI) {
 		ctx?: ExtensionCtx,
 		autoload = true,
 		timeoutMs = PROPS_TIMEOUT_MS,
-		selectedModel?: MutableDiscoveredModel,
+		selectedModel?: MutableModelMetadata,
 	): Promise<void> {
 		const model = currentModels.find((m) => m.id === modelId);
 		if (!model) {

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,15 @@ const DEFAULT_CONTEXT_WINDOW = 8192;
 const PROPS_TIMEOUT_MS = 120_000;
 
 const ModelsResponseSchema = Type.Object({
+	models: Type.Optional(
+		Type.Array(
+			Type.Object({
+				name: Type.Optional(Type.String()),
+				model: Type.Optional(Type.String()),
+				capabilities: Type.Optional(Type.Array(Type.String())),
+			}),
+		),
+	),
 	data: Type.Optional(
 		Type.Array(
 			Type.Object({
@@ -40,6 +49,7 @@ const ModelsResponseSchema = Type.Object({
 						input_modalities: Type.Optional(Type.Array(Type.String())),
 					}),
 				),
+				capabilities: Type.Optional(Type.Array(Type.String())),
 				meta: Type.Optional(
 					Type.Object({
 						n_ctx: Type.Optional(Type.Number()),
@@ -61,6 +71,13 @@ const PropsResponseSchema = Type.Object({
 	),
 	chat_template: Type.Optional(Type.String()),
 	build_info: Type.Optional(Type.String()),
+	modalities: Type.Optional(
+		Type.Object({
+			vision: Type.Optional(Type.Boolean()),
+			video: Type.Optional(Type.Boolean()),
+			audio: Type.Optional(Type.Boolean()),
+		}),
+	),
 });
 
 const validatePropsResponse = Compile(PropsResponseSchema);
@@ -77,14 +94,17 @@ const TEMPLATE_THINKING_LEVEL_MAP = {
 } satisfies NonNullable<LlamaModel["thinkingLevelMap"]>;
 
 // Minimal shape needed to update both registered models and Pi's active model snapshot.
-type MutableThinkingModel = {
+type MutableDiscoveredModel = {
+	id: string;
+	name: string;
+	input: LlamaModel["input"];
 	reasoning: boolean;
 	thinkingLevelMap?: LlamaModel["thinkingLevelMap"];
 	compat?: LlamaModel["compat"];
 };
 
 // Mark a model as using llama.cpp's chat_template_kwargs.enable_thinking control.
-function applyTemplateThinkingSupport(model: MutableThinkingModel): void {
+function applyTemplateThinkingSupport(model: MutableDiscoveredModel): void {
 	model.reasoning = true;
 	model.thinkingLevelMap = TEMPLATE_THINKING_LEVEL_MAP;
 	model.compat = {
@@ -93,6 +113,66 @@ function applyTemplateThinkingSupport(model: MutableThinkingModel): void {
 		// chat_template_kwargs.enable_thinking payload, not a Qwen-only option.
 		thinkingFormat: "qwen-chat-template",
 	};
+}
+
+function dedupeInputs(input: LlamaModel["input"]): LlamaModel["input"] {
+	return [...new Set(input)] as LlamaModel["input"];
+}
+
+function buildModelName(
+	id: string,
+	input: LlamaModel["input"],
+	isLoaded: boolean,
+	modalities?: { audio?: boolean; video?: boolean },
+): string {
+	const suffixes: string[] = [];
+	if (input.includes("image")) {
+		suffixes.push("image");
+	}
+	if (modalities?.audio) {
+		suffixes.push("audio");
+	}
+	if (modalities?.video) {
+		suffixes.push("video");
+	}
+	if (isLoaded) {
+		suffixes.push("loaded");
+	}
+	return suffixes.length > 0 ? `${id} (${suffixes.join(", ")})` : id;
+}
+
+function getModelInputFromListing(model: {
+	architecture?: { input_modalities?: string[] };
+	capabilities?: string[];
+}): LlamaModel["input"] {
+	const input: LlamaModel["input"] = ["text"];
+	for (const modality of model.architecture?.input_modalities ?? []) {
+		if (modality === "text" || modality === "image") {
+			input.push(modality);
+		}
+	}
+	if (model.capabilities?.includes("multimodal")) {
+		input.push("image");
+	}
+	return dedupeInputs(input);
+}
+
+function applyPropsModalities(
+	model: MutableDiscoveredModel,
+	isLoaded: boolean,
+	modalities?: { vision?: boolean; audio?: boolean; video?: boolean },
+): boolean {
+	let updated = false;
+	if (modalities?.vision && !model.input.includes("image")) {
+		model.input = dedupeInputs([...model.input, "image"]);
+		updated = true;
+	}
+	const nextName = buildModelName(model.id, model.input, isLoaded, modalities);
+	if (model.name !== nextName) {
+		model.name = nextName;
+		updated = true;
+	}
+	return updated;
 }
 
 export default async function (pi: ExtensionAPI) {
@@ -147,24 +227,27 @@ export default async function (pi: ExtensionAPI) {
 			}
 
 			const previousById = new Map(currentModels.map((m) => [m.id, m]));
+			const listingCapabilitiesById = new Map<string, string[]>();
+			for (const listedModel of payload.models ?? []) {
+				const capabilities = listedModel.capabilities ?? [];
+				if (listedModel.model) {
+					listingCapabilitiesById.set(listedModel.model, capabilities);
+				}
+				if (listedModel.name) {
+					listingCapabilitiesById.set(listedModel.name, capabilities);
+				}
+			}
 
 			currentModels = (payload.data ?? []).map((model) => {
 				const previous = previousById.get(model.id);
 				const isLoaded = model.status?.value === "loaded";
-				const modalities = model.architecture?.input_modalities ?? ["text"];
-				const input = modalities.filter(
-					(m): m is "text" | "image" => m === "text" || m === "image",
-				);
-				const suffixes: string[] = [];
-				if (input.includes("image")) {
-					suffixes.push("(image)");
-				}
-				if (isLoaded) {
-					suffixes.push("(loaded)");
-				}
+				const input = getModelInputFromListing({
+					...model,
+					capabilities: model.capabilities ?? listingCapabilitiesById.get(model.id),
+				});
 				return {
 					id: model.id,
-					name: suffixes.length > 0 ? `${model.id} ${suffixes.join(" ")}` : model.id,
+					name: buildModelName(model.id, input, isLoaded),
 					// /v1/models does not include /props-discovered capabilities, so preserve
 					// template thinking metadata across refreshes.
 					reasoning: previous?.reasoning ?? false,
@@ -209,7 +292,7 @@ export default async function (pi: ExtensionAPI) {
 		ctx?: ExtensionCtx,
 		autoload = true,
 		timeoutMs = PROPS_TIMEOUT_MS,
-		selectedModel?: MutableThinkingModel,
+		selectedModel?: MutableDiscoveredModel,
 	): Promise<void> {
 		const model = currentModels.find((m) => m.id === modelId);
 		if (!model) {
@@ -217,8 +300,10 @@ export default async function (pi: ExtensionAPI) {
 		}
 		if (discoveredMetadata.has(modelId)) {
 			// Provider re-registration does not update Pi's active model snapshot, so copy
-			// already-discovered thinking metadata into the selected model when available.
-			if (selectedModel && model.reasoning) {
+			// already-discovered metadata into the selected model when available.
+			if (selectedModel) {
+				selectedModel.name = model.name;
+				selectedModel.input = model.input;
 				selectedModel.reasoning = model.reasoning;
 				selectedModel.thinkingLevelMap = model.thinkingLevelMap;
 				selectedModel.compat = model.compat;
@@ -263,9 +348,18 @@ export default async function (pi: ExtensionAPI) {
 			}
 			const nCtx = data.default_generation_settings?.n_ctx;
 			let updated = false;
+			const isLoaded = model.name.includes("loaded");
+			updated = applyPropsModalities(model, isLoaded, data.modalities) || updated;
+			if (selectedModel) {
+				updated = applyPropsModalities(selectedModel, isLoaded, data.modalities) || updated;
+			}
 			let loadedFooterStatus = autoload ? `[llama.cpp] ${modelId} loaded` : undefined;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
+				model.name = buildModelName(model.id, model.input, true, data.modalities);
+				if (selectedModel) {
+					selectedModel.name = model.name;
+				}
 				loadedFooterStatus = `[llama.cpp] ${modelId} loaded with ctx ${nCtx} tokens`;
 				updated = true;
 			}

--- a/index.ts
+++ b/index.ts
@@ -83,6 +83,11 @@ const PropsResponseSchema = Type.Object({
 const validatePropsResponse = Compile(PropsResponseSchema);
 
 type LlamaModel = NonNullable<Parameters<ExtensionAPI["registerProvider"]>[1]["models"]>[number];
+type DiscoveredCapabilities = {
+	multimodal?: boolean;
+	audio?: boolean;
+	video?: boolean;
+};
 type ExtensionCtx = Parameters<Parameters<ExtensionAPI["on"]>[1]>[1];
 
 // llama.cpp template thinking is boolean, so expose Pi's default off/medium toggle only.
@@ -123,16 +128,18 @@ function buildModelName(
 	id: string,
 	input: LlamaModel["input"],
 	isLoaded: boolean,
-	modalities?: { audio?: boolean; video?: boolean },
+	capabilities?: DiscoveredCapabilities,
 ): string {
 	const suffixes: string[] = [];
 	if (input.includes("image")) {
 		suffixes.push("image");
+	} else if (capabilities?.multimodal) {
+		suffixes.push("multimodal");
 	}
-	if (modalities?.audio) {
+	if (capabilities?.audio) {
 		suffixes.push("audio");
 	}
-	if (modalities?.video) {
+	if (capabilities?.video) {
 		suffixes.push("video");
 	}
 	if (isLoaded) {
@@ -143,7 +150,6 @@ function buildModelName(
 
 function getModelInputFromListing(model: {
 	architecture?: { input_modalities?: string[] };
-	capabilities?: string[];
 }): LlamaModel["input"] {
 	const input: LlamaModel["input"] = ["text"];
 	for (const modality of model.architecture?.input_modalities ?? []) {
@@ -151,28 +157,42 @@ function getModelInputFromListing(model: {
 			input.push(modality);
 		}
 	}
-	if (model.capabilities?.includes("multimodal")) {
-		input.push("image");
-	}
 	return dedupeInputs(input);
+}
+
+function getDiscoveredCapabilitiesFromListing(model: {
+	capabilities?: string[];
+}): DiscoveredCapabilities {
+	return {
+		multimodal: model.capabilities?.includes("multimodal") === true || undefined,
+	};
 }
 
 function applyPropsModalities(
 	model: MutableDiscoveredModel,
 	isLoaded: boolean,
+	capabilities: DiscoveredCapabilities,
 	modalities?: { vision?: boolean; audio?: boolean; video?: boolean },
-): boolean {
+): { updated: boolean; capabilities: DiscoveredCapabilities } {
 	let updated = false;
 	if (modalities?.vision && !model.input.includes("image")) {
 		model.input = dedupeInputs([...model.input, "image"]);
 		updated = true;
 	}
-	const nextName = buildModelName(model.id, model.input, isLoaded, modalities);
+	const nextCapabilities: DiscoveredCapabilities = {
+		...capabilities,
+		audio: modalities?.audio || capabilities.audio || undefined,
+		video: modalities?.video || capabilities.video || undefined,
+	};
+	if (capabilities.audio !== nextCapabilities.audio || capabilities.video !== nextCapabilities.video) {
+		updated = true;
+	}
+	const nextName = buildModelName(model.id, model.input, isLoaded, nextCapabilities);
 	if (model.name !== nextName) {
 		model.name = nextName;
 		updated = true;
 	}
-	return updated;
+	return { updated, capabilities: nextCapabilities };
 }
 
 export default async function (pi: ExtensionAPI) {
@@ -241,13 +261,16 @@ export default async function (pi: ExtensionAPI) {
 			currentModels = (payload.data ?? []).map((model) => {
 				const previous = previousById.get(model.id);
 				const isLoaded = model.status?.value === "loaded";
-				const input = getModelInputFromListing({
-					...model,
-					capabilities: model.capabilities ?? listingCapabilitiesById.get(model.id),
-				});
+				const input = getModelInputFromListing(model);
+				const discoveredCapabilities =
+					discoveredCapabilitiesById.get(model.id) ??
+					getDiscoveredCapabilitiesFromListing({
+						capabilities: model.capabilities ?? listingCapabilitiesById.get(model.id),
+					});
+				discoveredCapabilitiesById.set(model.id, discoveredCapabilities);
 				return {
 					id: model.id,
-					name: buildModelName(model.id, input, isLoaded),
+					name: buildModelName(model.id, input, isLoaded, discoveredCapabilities),
 					// /v1/models does not include /props-discovered capabilities, so preserve
 					// template thinking metadata across refreshes.
 					reasoning: previous?.reasoning ?? false,
@@ -277,6 +300,7 @@ export default async function (pi: ExtensionAPI) {
 	}
 
 	const discoveredMetadata = new Set<string>();
+	const discoveredCapabilitiesById = new Map<string, DiscoveredCapabilities>();
 	const pendingMetadata = new Set<string>();
 	let statusTimeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -349,14 +373,19 @@ export default async function (pi: ExtensionAPI) {
 			const nCtx = data.default_generation_settings?.n_ctx;
 			let updated = false;
 			const isLoaded = model.name.includes("loaded");
-			updated = applyPropsModalities(model, isLoaded, data.modalities) || updated;
+			const currentCapabilities = discoveredCapabilitiesById.get(modelId) ?? {};
+			const modelUpdate = applyPropsModalities(model, isLoaded, currentCapabilities, data.modalities);
+			discoveredCapabilitiesById.set(modelId, modelUpdate.capabilities);
+			updated = modelUpdate.updated || updated;
 			if (selectedModel) {
-				updated = applyPropsModalities(selectedModel, isLoaded, data.modalities) || updated;
+				updated =
+					applyPropsModalities(selectedModel, isLoaded, modelUpdate.capabilities, data.modalities).updated ||
+					updated;
 			}
 			let loadedFooterStatus = autoload ? `[llama.cpp] ${modelId} loaded` : undefined;
 			if (typeof nCtx === "number" && nCtx > 0) {
 				model.contextWindow = nCtx;
-				model.name = buildModelName(model.id, model.input, true, data.modalities);
+				model.name = buildModelName(model.id, model.input, true, discoveredCapabilitiesById.get(model.id));
 				if (selectedModel) {
 					selectedModel.name = model.name;
 				}


### PR DESCRIPTION
After trying to understand why Gemma-4-12b accepted picture/audio via native webui, I asked GPT-5.4-mid to take a look at the pi-llama provider.

Provider was only looking at old format (input_modalities) and multimodal from Gemma-4-12b was never considered.

With minimal changes, it's working.