### PR TITLE
Add support for json settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,31 @@ pi -e ~/code/pi-llama/index.ts
 `-e` loads the extension only for the current session, useful while
 developing.
 
-## Environment Variables
+## Configuration
 
-This extension supports the following environment variables:
+This extension supports configuration via JSON files and environment variables.
 
-- LLAMA_BASE_URL (Default: `http://localhost:8080/v1`)
-- LLAMA_API_KEY (Default: `no-key`)
+**Config file paths:**
+- Global: `~/.pi/agent/pi-llama.json`
+- Project: `<cwd>/.pi/pi-llama.json`
+
+**Precedence (highest to lowest):**
+1. Environment variables (`LLAMA_BASE_URL`, `LLAMA_API_KEY`)
+2. Project config (`<cwd>/.pi/pi-llama.json`)
+3. Global config (`~/.pi/agent/pi-llama.json`)
+4. Hardcoded defaults
+
+**Example config file:**
+```json
+{
+  "baseUrl": "http://server.local:8888/v1",
+  "apiKey": "your-api-key"
+}
+```
+
+**Environment variables:**
+- `LLAMA_BASE_URL` (Default: `http://localhost:8080/v1`)
+- `LLAMA_API_KEY` (Default: `no-key`)
 
 ## Usage
 

--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,16 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { Compile } from "typebox/compile";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+type LlamaConfig = {
+	baseUrl?: string;
+	apiKey?: string;
+};
 
 const PROVIDER_ID = "llama-cpp";
 const DEFAULT_BASE_URL = "http://localhost:8080/v1";
@@ -20,6 +28,42 @@ const DEFAULT_CONTEXT_WINDOW = 8192;
 // maxTokens (see model-registry.ts parseModels).
 const DEFAULT_MAX_TOKENS = 16384;
 const PROPS_TIMEOUT_MS = 120_000;
+
+function getConfigPaths(cwd: string): { globalPath: string; projectPath: string } {
+	return {
+		globalPath: join(getAgentDir(), "pi-llama.json"),
+		projectPath: join(cwd, ".pi", "pi-llama.json"),
+	};
+}
+
+// Precedence: env vars > project config > global config > defaults.
+function loadConfig(cwd: string): LlamaConfig {
+	const { globalPath, projectPath } = getConfigPaths(cwd);
+
+	let config: LlamaConfig = {};
+
+	if (existsSync(globalPath)) {
+		try {
+			config = { ...config, ...JSON.parse(readFileSync(globalPath, "utf-8")) };
+		} catch (e) {
+			console.warn(`[llama-cpp] could not parse ${globalPath}: ${e}`);
+		}
+	}
+
+	if (existsSync(projectPath)) {
+		try {
+			config = { ...config, ...JSON.parse(readFileSync(projectPath, "utf-8")) };
+		} catch (e) {
+			console.warn(`[llama-cpp] could not parse ${projectPath}: ${e}`);
+		}
+	}
+
+	// Env vars override everything.
+	if (process.env.LLAMA_BASE_URL) config.baseUrl = process.env.LLAMA_BASE_URL;
+	if (process.env.LLAMA_API_KEY) config.apiKey = process.env.LLAMA_API_KEY;
+
+	return config;
+}
 
 const ModelsResponseSchema = Type.Object({
 	data: Type.Optional(
@@ -132,8 +176,9 @@ export default async function (pi: ExtensionAPI) {
 		},
 	});
 
-	const baseUrl = (process.env.LLAMA_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
-	const apiKey = process.env.LLAMA_API_KEY ?? "no-key";
+	const config = loadConfig(process.cwd());
+	const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+	const apiKey = config.apiKey ?? "no-key";
 
 	async function refreshProvider(): Promise<void> {
 		try {


### PR DESCRIPTION
Adds JSON config file support for `baseUrl` and `apiKey`. File paths match pattern used by the `pi-sandbox` extension.

**Config file paths:**
- Global: `~/.pi/agent/pi-llama.json`
- Project: `<cwd>/.pi/pi-llama.json`

**Precedence (highest to lowest):**
1. Environment variables (`LLAMA_BASE_URL`, `LLAMA_API_KEY`)
2. Project config (`<cwd>/.pi/pi-llama.json`)
3. Global config (`~/.pi/agent/pi-llama.json`)
4. Hardcoded defaults

**Example config file:**
```json
{
  "baseUrl": "http://server.local:8888/v1",
  "apiKey": "your-api-key"
}
```

- Uses `getAgentDir()` from the Pi SDK for global path resolution
- Uses `existsSync()` checks before reading (no crashes on missing files)
- Warns on malformed JSON instead of silently failing

AI usage: pi + Qwen 27b
